### PR TITLE
breaking: Change types of first and last from Float to Int

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -84,14 +84,14 @@ type Query {
     before: Cursor
 
     """Grabs the last n records."""
-    last: Float
+    last: Int
   ): Boolean!
   pagingForward(
     """Grabs records starting from after the given cursor."""
     after: Cursor
 
     """Grabs the first n records."""
-    first: Float
+    first: Int
   ): Boolean!
 }
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -34,6 +34,34 @@ test("can paginate", async () => {
   `);
 });
 
+test("expects first and last to be Int ", async () => {
+  const schema = await buildSchema({
+    resolvers: [ItemResolver],
+  });
+  const answer = execute({
+    schema,
+    document: gql`
+      #graphql
+      query ($first: Int, $last: Int) {
+        pagingForward(first: $first)
+        pagingBackward(last: $last)
+      }
+    `,
+    variableValues: {
+      first: 3,
+      last: 5,
+    },
+  });
+  expect(await answer).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "pagingBackward": true,
+        "pagingForward": true,
+      },
+    }
+  `);
+});
+
 test("can getItems", async () => {
   const schema = await buildSchema({
     resolvers: [ItemResolver],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Field, ArgsType, ClassType } from "type-graphql";
+import { ObjectType, Field, ArgsType, ClassType, Int } from "type-graphql";
 import CursorScalar, { serializeCursor, deserializeCursor } from "./cursor";
 import type { Cursor } from "./cursor";
 type HasConstructor<T> = T & { constructor: { name: string } };
@@ -20,7 +20,7 @@ export class ForwardPaginationArgs<CursorType extends Cursor = Cursor> {
   /** Grabs the first n records.
    * @public
    */
-  @Field(() => Number, {
+  @Field(() => Int, {
     nullable: true,
     description: "Grabs the first n records.",
   })
@@ -44,7 +44,7 @@ export class BackwardPaginationArgs<CursorType extends Cursor = Cursor> {
   /** Grabs the last n records.
    * @public
    */
-  @Field(() => Number, {
+  @Field(() => Int, {
     nullable: true,
     description: "Grabs the last n records.",
   })
@@ -67,7 +67,7 @@ export class FullPaginationArgs<CursorType extends Cursor = Cursor>
   /** Grabs the last n records.
    * @public
    */
-  @Field(() => Number, {
+  @Field(() => Int, {
     nullable: true,
     description: "Grabs the last n records.",
   })
@@ -85,7 +85,7 @@ export class FullPaginationArgs<CursorType extends Cursor = Cursor>
   /** Grabs the first n records.
    * @public
    */
-  @Field(() => Number, {
+  @Field(() => Int, {
     nullable: true,
     description: "Grabs the first n records.",
   })


### PR DESCRIPTION
`type-graphql` resolves Number as the GraphQL Float type, but the [relay specification](https://relay.dev/graphql/connections.htm#sec-Arguments) says they should be integers. This changes the types. to Int.

This will be a breaking change, because GraphQL schemas generated with this library will change.